### PR TITLE
Fixed the problem that bin name in install.js and use bin.js are diff…

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -16,9 +16,16 @@ const archMap = {
   arm64: 'arm64',
 }
 
+const platformMap = {
+  darwin: 'darwin',
+  win32: 'windows',
+  linux: 'linux',
+  freebsd: 'freebsd',
+}
+
 const ext = platform === 'win32' ? '.exe' : ''
 
-const binaryName = `tsgo-${platform}-${archMap[arch]}${ext}`
+const binaryName = `tsgo-${platformMap[platform]}-${archMap[arch]}${ext}`;
 
 const binaryPath = join(path.dirname(fileURLToPath(import.meta.url)), 'bin', binaryName)
 


### PR DESCRIPTION
…erent, under Windows system

Fixed the problem that bin name in install.js and use bin.js are different, under Windows system