### PR TITLE
Add support to supply your binary/options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ This unofficial package allows developers to:
 npm install @rxliuli/tsgo
 ```
 
+### Optional Installation Parameters
+
+You may add these environment variables to your system to invoke custom installation parameters:   
+- `TSGO_DIRECTORY` : If you do not want to download a copy of `tsgo` that someone else built, you can specify this environment variable. This should be a path to the directory, where the `typescript-go` project is, should contain the partial path `./built/local/tsgo`.
+- `TSGO_PROVIDER` : If you want to download a copy of `tsgo` from a custom GitHub user, you can specify this environment variable. This should be a GitHub username that has releases for `tsgo`.
+
 ## Usage
 
 This package provides the `tsgo` binary which functions similarly to `tsc`:

--- a/install.js
+++ b/install.js
@@ -46,7 +46,7 @@ if (existsSync(binaryPath)) {
 
 async function download() {
   if (env.TSGO_DIRECTORY) {
-    const filePath = join(env.TSGO_DIRECTORY, 'built', 'local', 'tsgo.exe')
+    const filePath = join(env.TSGO_DIRECTORY, 'built', 'local', `tsgo${ext}`)
 
     if (existsSync(filePath)) {
       try {

--- a/install.js
+++ b/install.js
@@ -1,6 +1,7 @@
-import { existsSync, chmodSync } from 'node:fs'
+import { existsSync, chmodSync, constants } from 'node:fs'
 import path, { join } from 'node:path'
-import { mkdir, writeFile } from 'node:fs/promises'
+import process, { env } from 'node:process'
+import { mkdir, writeFile, copyFile } from 'node:fs/promises'
 import json from './package.json' with { type: 'json' }
 import { fileURLToPath } from 'node:url'
 
@@ -25,7 +26,13 @@ const ext = platform === 'win32' ? '.exe' : ''
 
 const binaryName = `tsgo-${platformMap[platform]}-${archMap[arch]}${ext}`
 
-const downloadUrl = `https://github.com/rxliuli/tsgo-npm-release/releases/download/v${json.version}/${binaryName}`
+let tsgoProvider = 'rxliuli'
+
+if (env.TSGO_PROVIDER) {
+  tsgoProvider = env.TSGO_PROVIDER
+}
+
+const downloadUrl = `https://github.com/${tsgoProvider}/tsgo-npm-release/releases/download/v${json.version}/${binaryName}`
 
 const binDir = join(path.dirname(fileURLToPath(import.meta.url)), 'bin')
 await mkdir(binDir, { recursive: true })
@@ -38,6 +45,24 @@ if (existsSync(binaryPath)) {
 }
 
 async function download() {
+  if (env.TSGO_DIRECTORY) {
+    const filePath = join(env.TSGO_DIRECTORY, 'built', 'local', 'tsgo.exe')
+
+    if (existsSync(filePath)) {
+      try {
+        await copyFile(filePath, binaryPath, constants.COPYFILE_EXCL)
+
+        if (platform !== 'win32') {
+          await chmod(binaryPath, 0o755)
+        }
+
+        process.exit(0);
+      } catch (error) {
+        console.error(`Copy file failed: ${error.message}`)
+      }
+    }
+  }
+
   console.log(
     `Downloading binary file for ${platformMap[platform]}-${archMap[arch]}...`,
   )


### PR DESCRIPTION
- Add support to supply own binary.
- Add support to specify custom user to download from.
- Refactored some code.

The script falls back to downloading if unsuccessful.   
Maybe add an option to not fall back to downloading, but that can also be easily achieved via setting the environment variable `TSGO_PROVIDER` to an empty string.

Added environment variables:   
`TSGO_DIRECTORY`: The directory, where the `typescript-go` project is, should contain the partial path `./built/local/tsgo.exe`.
`TSGO_PROVIDER`: A GitHub username that has releases for `tsgo`